### PR TITLE
Remove broken path errors

### DIFF
--- a/SourceSinkPushPull/info.json
+++ b/SourceSinkPushPull/info.json
@@ -1,6 +1,6 @@
 {
     "name": "SourceSinkPushPull",
-    "version": "0.3.4",
+    "version": "0.3.3",
     "title": "SSPP Logistics Train Mod",
     "author": "jagoly",
     "factorio_version": "2.0",

--- a/SourceSinkPushPull/info.json
+++ b/SourceSinkPushPull/info.json
@@ -1,6 +1,6 @@
 {
     "name": "SourceSinkPushPull",
-    "version": "0.3.3",
+    "version": "0.3.4",
     "title": "SSPP Logistics Train Mod",
     "author": "jagoly",
     "factorio_version": "2.0",

--- a/SourceSinkPushPull/scripts/lib.lua
+++ b/SourceSinkPushPull/scripts/lib.lua
@@ -533,6 +533,7 @@ end
 
 ---@param stop LuaEntity
 function create_direct_to_station_order(stop)
+    -- Function from Cybersyn
     local conditions_direct_to_station = { { type = "time", compare_type = "and", ticks = 1 } }
     return {
         rail = stop.connected_rail,
@@ -552,13 +553,6 @@ function send_hauler_to_station(hauler, station)
         create_direct_to_station_order(stop),
         { station = stop.backer_name } },
     }
-
-    local state = train.state
-    if state == defines.train_state.no_path then
-        set_hauler_status(hauler, { "sspp-alert.no-path-to-station" }, hauler.status_item, stop)
-        send_alert_for_train(train, hauler.status)
-        train.manual_mode = true
-    end
 end
 
 ---@param hauler Hauler
@@ -567,13 +561,6 @@ function send_hauler_to_named_stop(hauler, stop_name)
     local train = hauler.train
 
     train.schedule = { current = 1, records = { { station = stop_name } } }
-
-    local state = train.state
-    if state == defines.train_state.no_path or state == defines.train_state.destination_full then
-        set_hauler_status(hauler, { "sspp-alert.no-path-to-named-stop", stop_name }, hauler.status_item)
-        send_alert_for_train(train, hauler.status)
-        train.manual_mode = true
-    end
 end
 
 ---@param hauler Hauler

--- a/SourceSinkPushPull/scripts/lib.lua
+++ b/SourceSinkPushPull/scripts/lib.lua
@@ -534,11 +534,9 @@ end
 ---@param stop LuaEntity
 function create_direct_to_station_order(stop)
     -- Function from Cybersyn
-    local conditions_direct_to_station = { { type = "time", compare_type = "and", ticks = 1 } }
     return {
         rail = stop.connected_rail,
         rail_direction = stop.connected_rail_direction,
-        wait_conditions = conditions_direct_to_station,
     }
 end
 

--- a/SourceSinkPushPull/scripts/lib.lua
+++ b/SourceSinkPushPull/scripts/lib.lua
@@ -548,7 +548,6 @@ function send_hauler_to_station(hauler, station)
     local train = hauler.train
     local stop = station.stop
 
-    stop.trains_limit = nil
     train.schedule = { current = 1, records = {
         create_direct_to_station_order(stop),
         { station = stop.backer_name } },

--- a/SourceSinkPushPull/scripts/lib.lua
+++ b/SourceSinkPushPull/scripts/lib.lua
@@ -531,6 +531,16 @@ function set_haulers_to_manual(hauler_ids, message, item, stop)
     end
 end
 
+---@param stop LuaEntity
+function create_direct_to_station_order(stop)
+    local conditions_direct_to_station = { { type = "time", compare_type = "and", ticks = 1 } }
+    return {
+        rail = stop.connected_rail,
+        rail_direction = stop.connected_rail_direction,
+        wait_conditions = conditions_direct_to_station,
+    }
+end
+
 ---@param hauler Hauler
 ---@param station Station
 function send_hauler_to_station(hauler, station)
@@ -538,9 +548,10 @@ function send_hauler_to_station(hauler, station)
     local stop = station.stop
 
     stop.trains_limit = nil
-    train.schedule = { current = 1, records = { { station = stop.backer_name } } }
-    train.recalculate_path()
-    stop.trains_limit = 0
+    train.schedule = { current = 1, records = {
+        create_direct_to_station_order(stop),
+        { station = stop.backer_name } },
+    }
 
     local state = train.state
     if state == defines.train_state.no_path then
@@ -556,7 +567,6 @@ function send_hauler_to_named_stop(hauler, stop_name)
     local train = hauler.train
 
     train.schedule = { current = 1, records = { { station = stop_name } } }
-    train.recalculate_path()
 
     local state = train.state
     if state == defines.train_state.no_path or state == defines.train_state.destination_full then

--- a/SourceSinkPushPull/scripts/main.lua
+++ b/SourceSinkPushPull/scripts/main.lua
@@ -83,13 +83,6 @@ local function on_train_changed_state(event)
         return
     end
 
-    if state == defines.train_state.destination_full then
-        set_hauler_status(hauler, { "sspp-alert.path-broken" })
-        send_alert_for_train(train, hauler.status)
-        train.manual_mode = true
-        return
-    end
-
     if hauler.to_provide then
         if hauler.to_provide.phase == "TRAVEL" then
             -- Only process if train is stopped at station, not a rail connection.

--- a/SourceSinkPushPull/scripts/main.lua
+++ b/SourceSinkPushPull/scripts/main.lua
@@ -83,7 +83,7 @@ local function on_train_changed_state(event)
         return
     end
 
-    if state == defines.train_state.no_path or state == defines.train_state.destination_full then
+    if state == defines.train_state.destination_full then
         set_hauler_status(hauler, { "sspp-alert.path-broken" })
         send_alert_for_train(train, hauler.status)
         train.manual_mode = true

--- a/SourceSinkPushPull/scripts/main.lua
+++ b/SourceSinkPushPull/scripts/main.lua
@@ -92,7 +92,7 @@ local function on_train_changed_state(event)
 
     if hauler.to_provide then
         if hauler.to_provide.phase == "TRAVEL" then
-            if state == defines.train_state.wait_station then
+            if state == defines.train_state.wait_station and train.station ~= nil then
                 main.hauler_arrived_at_provide_station(hauler)
             end
         elseif hauler.to_provide.phase == "TRANSFER" then
@@ -105,7 +105,7 @@ local function on_train_changed_state(event)
 
     if hauler.to_request then
         if hauler.to_request.phase == "TRAVEL" then
-            if state == defines.train_state.wait_station then
+            if state == defines.train_state.wait_station and train.station ~= nil then
                 main.hauler_arrived_at_request_station(hauler)
             end
         elseif hauler.to_request.phase == "TRANSFER" then

--- a/SourceSinkPushPull/scripts/main.lua
+++ b/SourceSinkPushPull/scripts/main.lua
@@ -93,7 +93,7 @@ local function on_train_changed_state(event)
     if hauler.to_provide then
         if hauler.to_provide.phase == "TRAVEL" then
             -- Only process if train is stopped at station, not a rail connection.
-            if state == defines.train_state.wait_station and train.station ~= nil then
+            if state == defines.train_state.wait_station and train.station then
                 main.hauler_arrived_at_provide_station(hauler)
             end
         elseif hauler.to_provide.phase == "TRANSFER" then
@@ -107,7 +107,7 @@ local function on_train_changed_state(event)
     if hauler.to_request then
         if hauler.to_request.phase == "TRAVEL" then
             -- Only process if train is stopped at station, not a rail connection.
-            if state == defines.train_state.wait_station and train.station ~= nil then
+            if state == defines.train_state.wait_station and train.station then
                 main.hauler_arrived_at_request_station(hauler)
             end
         elseif hauler.to_request.phase == "TRANSFER" then

--- a/SourceSinkPushPull/scripts/main.lua
+++ b/SourceSinkPushPull/scripts/main.lua
@@ -92,6 +92,7 @@ local function on_train_changed_state(event)
 
     if hauler.to_provide then
         if hauler.to_provide.phase == "TRAVEL" then
+            -- Only process if train is stopped at station, not a rail connection.
             if state == defines.train_state.wait_station and train.station ~= nil then
                 main.hauler_arrived_at_provide_station(hauler)
             end
@@ -105,6 +106,7 @@ local function on_train_changed_state(event)
 
     if hauler.to_request then
         if hauler.to_request.phase == "TRAVEL" then
+            -- Only process if train is stopped at station, not a rail connection.
             if state == defines.train_state.wait_station and train.station ~= nil then
                 main.hauler_arrived_at_request_station(hauler)
             end

--- a/SourceSinkPushPull/scripts/main/station.lua
+++ b/SourceSinkPushPull/scripts/main/station.lua
@@ -162,7 +162,7 @@ function main.stop_built(stop, ghost_unit_number)
     if not read_stop_flag(stop, e_stop_flags.custom_name) then
         stop.backer_name = "[virtual-signal=signal-ghost]"
     end
-    stop.trains_limit = 0
+    stop.trains_limit = nil
 
     local stop_cb = stop.get_or_create_control_behavior() --[[@as LuaTrainStopControlBehavior]]
     stop_cb.read_from_train = true

--- a/SourceSinkPushPull/scripts/migrations.lua
+++ b/SourceSinkPushPull/scripts/migrations.lua
@@ -5,6 +5,12 @@ local flib_migration = require("__flib__.migration")
 --------------------------------------------------------------------------------
 
 local migrations = {
+    ["0.3.4"] = function()
+        for _, station in pairs(storage.stations) do
+            station.stop.trains_limit = nil
+            station.network = station.stop.surface.name
+        end
+    end,
     ["0.3.2"] = function()
         for _, network in pairs(storage.networks) do
             for _, class in pairs(network.classes) do

--- a/SourceSinkPushPull/scripts/migrations.lua
+++ b/SourceSinkPushPull/scripts/migrations.lua
@@ -7,8 +7,9 @@ local flib_migration = require("__flib__.migration")
 local migrations = {
     ["0.3.4"] = function()
         for _, station in pairs(storage.stations) do
-            station.stop.trains_limit = nil
-            station.network = station.stop.surface.name
+            if station.stop.valid then
+                station.stop.trains_limit = nil
+            end
         end
     end,
     ["0.3.2"] = function()


### PR DESCRIPTION
As mentioned [here](https://mods.factorio.com/mod/SourceSinkPushPull/discussion/6790ff35baea9024aaaf4d07), I have removed broken path errors. 

> This is at least how CS handles it. Once a train is dispatched it does not check if there is a path break. It doesn't even check for a valid path when dispatching (besides check they are the same surface). This is still useful behavior since it makes it very visible when a train cannot get somewhere. The only error you'll get from the mod is a stuck train error if a train doesn't arrive somewhere after a few minutes. I think that is the key, as far as the mod is concerned, broken paths aren't even a concept so they don't need to be specially handled. Path errors are vanilla train behavior which works pretty well without a mod doing anything.

Since trains recalculate their path when a path is fixed. The way stations were reserved before would break. I changed the way dispatches work with rail stops before stations like in cybersyn. The resulting behavior appears to be the same in my testing.

